### PR TITLE
Update tracing-subscriber version and release v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-dipstick"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Michal 'vorner' Vaner <vorner@vorner.cz>"]
 description = "Bridge from tracing instrumentation to the dipstick metrics library"
 documentation = "https://docs.rs/tracing-dipstick"
@@ -8,16 +8,16 @@ repository = "https://github.com/vorner/tracing-dipstick"
 readme = "README.md"
 keywords = ["tracing", "dipstick", "metrics"]
 categories = ["development-tools::debugging", "development-tools::profiling"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0/MIT"
 
 [dependencies]
 dipstick = "0.9"
 once_cell = "1"
 tracing-core = { version = "0.1", default-features = false, features = ["std"] }
-tracing-subscriber = { version = "0.2", default-features = false, features = ["registry"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry"] }
 
 [dev-dependencies]
-env_logger = "0.8"
+env_logger = "0.9"
 log = "0.4"
 tracing = { version = "0.1", default-features = true, features = ["log-always"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,7 +327,7 @@ where
     I: Subscriber,
     for<'l> I: LookupSpan<'l>,
 {
-    fn new_span(&self, attrs: &Attributes, id: &Id, ctx: Context<I>) {
+    fn on_new_span(&self, attrs: &Attributes, id: &Id, ctx: Context<I>) {
         let named = |scope: &S| -> S {
             let mut named: Option<S> = None;
             struct NameVisitor<'a, S> {


### PR DESCRIPTION
### Notes
* Update `tracing-subscriber` to latest version to be compatible with other rust packages using latest tracing framework versions. Running into following issue without this `tracing-subscriber` version update:

```
3c22fb97fdbb:tracing-dipstick-test asahith$ cargo build
    Updating crates.io index
   Compiling tracing-subscriber v0.2.25
   Compiling tracing-dipstick v0.1.1
   Compiling tracing-dipstick-test v0.1.0 (/Users/asahith/workplace/tracing/tracing-dipstick-test)
error[E0277]: the trait bound `DipstickLayer<AtomicBucket>: __tracing_subscriber_Layer<Registry>` is not satisfied
    --> src/main.rs:31:47
     |
31   |     let subscriber = Registry::default().with(bridge);
     |                                          ---- ^^^^^^ the trait `__tracing_subscriber_Layer<Registry>` is not implemented for `DipstickLayer<AtomicBucket>`
     |                                          |
     |                                          required by a bound introduced by this call
     |
note: required by a bound in `with`
    --> /Users/asahith/.cargo/registry/src/github.com-1ecc6299db9ec823/tracing-subscriber-0.3.16/src/layer/mod.rs:1485:12
     |
1485 |         L: Layer<Self>,
     |            ^^^^^^^^^^^ required by this bound in `with`

error[E0277]: the trait bound `DipstickLayer<AtomicBucket>: __tracing_subscriber_Layer<Registry>` is not satisfied
  --> src/main.rs:33:36
   |
33 |     subscriber::set_global_default(subscriber).unwrap();
   |     ------------------------------ ^^^^^^^^^^ the trait `__tracing_subscriber_Layer<Registry>` is not implemented for `DipstickLayer<AtomicBucket>`
   |     |
   |     required by a bound introduced by this call
   |
   = note: required because of the requirements on the impl of `tracing::Subscriber` for `Layered<DipstickLayer<AtomicBucket>, Registry>`
note: required by a bound in `tracing::subscriber::set_global_default`
  --> /Users/asahith/.cargo/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/src/subscriber.rs:41:8
   |
41 |     S: Subscriber + Send + Sync + 'static,
   |        ^^^^^^^^^^ required by this bound in `tracing::subscriber::set_global_default`

error[E0283]: type annotations needed
  --> src/main.rs:48:9
   |
48 |         debug!(metrics.counter = "done", metrics.counter.legs = 4, "Shaving done");
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type `{integer}`
   |
   = note: multiple `impl`s satisfying `{integer}: Value` found in the `tracing_core` crate:
           - impl Value for i128;
           - impl Value for i16;
           - impl Value for i32;
           - impl Value for i64;
           and 8 more
   = note: required for the cast to the object type `dyn Value`
   = note: this error originates in the macro `$crate::valueset` (in Nightly builds, run with -Z macro-backtrace for more info)

Some errors have detailed explanations: E0277, E0283.
For more information about an error, try `rustc --explain E0277`.
error: could not compile `tracing-dipstick-test` due to 3 previous errors
```
* Update rust edition to 2021 and release new version `0.2.0` to avoid breaking changes for clients

### Testing
* Created a [binary crate](https://github.com/sahith/tracing-dipstick-test/blob/main/src/main.rs) with example taken from docs https://docs.rs/tracing-dipstick/latest/tracing_dipstick/ for testing this PR changes. Output:

```
3c22fb97fdbb:tracing-dipstick-test asahith$ cargo run
   Compiling tracing-dipstick-test v0.1.0 (/Users/asahith/workplace/tracing/tracing-dipstick-test)
    Finished dev [unoptimized + debuginfo] target(s) in 3.32s
     Running `target/debug/tracing-dipstick-test`
shaving.yak.active.count 20
shaving.yak.active.sum 0
shaving.yak.active.max 1
shaving.yak.active.min 0
shaving.yak.active.mean 0
shaving.yak.active.rate 0
shaving.yak.done.count 10
shaving.yak.done.sum 10
shaving.yak.done.max 1
shaving.yak.done.min 1
shaving.yak.done.mean 1
shaving.yak.done.rate 2
shaving.yak.legs.count 10
shaving.yak.legs.sum 40
shaving.yak.legs.max 4
shaving.yak.legs.min 4
shaving.yak.legs.mean 4
shaving.yak.legs.rate 8
shaving.yak.order.max 9
shaving.yak.order.min 0
shaving.yak.order.mean 5
shaving.yak.started.count 10
shaving.yak.started.sum 10
shaving.yak.started.max 1
shaving.yak.started.min 1
shaving.yak.started.mean 1
shaving.yak.started.rate 2
shaving.yak.time.count 10
shaving.yak.time.sum 639214
shaving.yak.time.max 65099
shaving.yak.time.min 61090
shaving.yak.time.mean 63921
shaving.yak.time.rate 2
```
